### PR TITLE
Update Hyperliquid explorer

### DIFF
--- a/assets/chains.json
+++ b/assets/chains.json
@@ -644,9 +644,9 @@
       "supportsShanghai": false,
       "isTestnet": false,
       "nativeCurrencySymbol": "HYPE",
-      "etherscanApiUrl": "https://hyperliquid.cloud.blockscout.com/api/v2",
-      "etherscanBaseUrl": "https://hyperliquid.cloud.blockscout.com",
-      "etherscanApiKeyName": "BLOCKSCOUT_API_KEY"
+      "etherscanApiUrl": "https://api.etherscan.io/v2/api?chainid=999",
+      "etherscanBaseUrl": "https://hyperevmscan.io",
+      "etherscanApiKeyName": "ETHERSCAN_API_KEY"
     },
     "1030": {
       "internalId": "Cfx",

--- a/src/named.rs
+++ b/src/named.rs
@@ -1679,8 +1679,8 @@ impl NamedChain {
                 ("https://api.testnet.teloscan.io/api", "https://testnet.teloscan.io")
             }
             Hyperliquid => (
-                "https://hyperliquid.cloud.blockscout.com/api/v2",
-                "https://hyperliquid.cloud.blockscout.com",
+                "https://api.etherscan.io/v2/api?chainid=999",
+                "https://hyperevmscan.io",
             ),
             Abstract => ("https://api.etherscan.io/v2/api?chainid=2741", "https://abscan.org"),
             AbstractTestnet => {
@@ -1783,7 +1783,8 @@ impl NamedChain {
             | ZkSyncTestnet
             | ZkSync
             | Sophon
-            | SophonTestnet => "ETHERSCAN_API_KEY",
+            | SophonTestnet
+            | Hyperliquid => "ETHERSCAN_API_KEY",
 
             Avalanche | AvalancheFuji => "SNOWTRACE_API_KEY",
 
@@ -1800,7 +1801,7 @@ impl NamedChain {
             | KaruraTestnet | Mode | ModeSepolia | Pgn | PgnSepolia | Shimmer | Zora
             | ZoraSepolia | Darwinia | Crab | Koi | Immutable | ImmutableTestnet | Soneium
             | SoneiumMinatoTestnet | World | WorldSepolia | Curtis | Ink | InkSepolia
-            | SuperpositionTestnet | Superposition | Vana | Story | Hyperliquid => {
+            | SuperpositionTestnet | Superposition | Vana | Story => {
                 "BLOCKSCOUT_API_KEY"
             }
 


### PR DESCRIPTION
## Summary
- point Hyperliquid chain to new hyperevmscan explorer and API
- update chain metadata

## Testing
- `cargo test --all-features`
- `cargo fmt --all` *(fails: `rustfmt` not installed)*

------
https://chatgpt.com/codex/tasks/task_b_686d37a77a6483338980a230318ca1b7